### PR TITLE
updated SDK and project dependencies to latest versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,12 +17,12 @@ repositories {
 
 // @@@SNIPSTART hello-world-project-template-java-gradle-dependencies
 dependencies {
-    implementation group: 'io.temporal', name: 'temporal-sdk', version: '1.18.2'
-    implementation group: 'org.slf4j',  name: 'slf4j-nop', version: '2.0.6'
+    implementation group: 'io.temporal', name: 'temporal-sdk', version: '1.31.0'
+    implementation group: 'org.slf4j',  name: 'slf4j-nop', version: '2.0.17'
     
-    testImplementation group: 'io.temporal', name: 'temporal-testing', version: '1.18.2'
+    testImplementation group: 'io.temporal', name: 'temporal-testing', version: '1.31.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.1.1'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.20.0'
 }
 // @@@SNIPEND
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -27,33 +27,33 @@
     <dependency>
       <groupId>io.temporal</groupId>
       <artifactId>temporal-sdk</artifactId>
-      <version>1.19.0</version>
+      <version>1.31.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>2.0.6</version>
+      <version>2.0.17</version>
     </dependency>
 
     <dependency>
       <groupId>io.temporal</groupId>
       <artifactId>temporal-testing</artifactId>
-      <version>1.19.0</version>
+      <version>1.31.0</version>
       <scope>test</scope>
     </dependency>  
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.1.1</version>
+      <version>5.20.0</version>
       <scope>test</scope>
     </dependency>  
   


### PR DESCRIPTION
## What was changed?

I updated the version numbers for the Temporal SDK and all project dependencies (junit, slf4j, commons-lang, etc.) to the latest stable versions. I did so for both Maven and Gradle.

## Why?

The Temporal SDK referenced in this tutorial was several versions behind what's current, as were other libraries it uses. I updated them to what is now the latest stable release. This eliminates security vulnerabilities in older versions of project dependencies and also conveys to our learners that our tutorials are maintained and worth their time to complete.

I tested this by running `gradle compileJava test` and `mvn compile test` on a clean checkout to ensure that the code compiled with the new versions and that all automated tests were successful. 

Note that this PR updates the code, but the prose for the tutorial is in a different repo and I've [submitted a PR](https://github.com/temporalio/temporal-learning/pull/424) there to handle that. Both PRs should be merged with minimal delay between them as possible.